### PR TITLE
HB-3199 usebraze-swift-sdk instead of appboy-ios-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ChangeLog
 ---------
 
+If the app is in background, it must not be launched but put in foreground.
+To avoid launching the app in this case, add the following in your config.xml file:
+`<preference name="AndroidLaunchMode" value="singleInstance"/>`
+
+Android 12 updates taken from: https://github.com/bhandaribhumin/cordova-plugin-local-notification-12/commit/0b6aefe0aac71cf44feb62a975516e13adfd010e
+
 Please also read the [Upgrade Guide](https://github.com/katzer/cordova-plugin-local-notifications/wiki/Upgrade-Guide) for more information.
 
 #### Version 0.8.5 (22.05.2017)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@
 
 ## Important Notice
 
+If the app is in background, it must not be launched but put in foreground.
+To avoid launching the app in this case, add the following in your config.xml file:
+`<preference name="AndroidLaunchMode" value="singleInstance"/>`
+
 Please make sure that you always read the tagged README for the version you're using.
 
 See the _0.8_ branch if you cannot upgrade. Further development for `v0.9-beta` will happen here. The `0.9-dev` and `ios10` branches are obsolate and will be removed soon.

--- a/plugin.xml
+++ b/plugin.xml
@@ -119,9 +119,10 @@
                 android:name="de.appplant.cordova.plugin.localnotification.ClearReceiver"
                 android:exported="false" />
 
-            <service
+            <activity
                 android:name="de.appplant.cordova.plugin.localnotification.ClickReceiver"
-                android:exported="false" />
+                android:exported="false"
+                android:theme="@style/Theme.AppCompat.NoActionBar" />
 
             <receiver
                 android:name="de.appplant.cordova.plugin.localnotification.RestoreReceiver"
@@ -185,6 +186,10 @@
 
         <source-file
             src="src/android/notification/receiver/AbstractTriggerReceiver.java"
+            target-dir="src/de/appplant/cordova/plugin/notification/receiver" />
+
+        <source-file
+            src="src/android/notification/receiver/NotificationTrampolineActivity.java"
             target-dir="src/de/appplant/cordova/plugin/notification/receiver" />
 
         <source-file

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -390,6 +390,7 @@ public final class Builder {
         if (clickActivity == null)
             return;
 
+        Double reqCode = random.nextDouble();
         Action[] actions = options.getActions();
         if (actions != null && actions.length > 0 ) {
           // if actions are defined, the user must click on button actions to launch the app.
@@ -398,6 +399,7 @@ public final class Builder {
         }
 
         Intent intent = new Intent(context, clickActivity)
+                .setAction(reqCode.toString())
                 .putExtra(Notification.EXTRA_ID, options.getId())
                 .putExtra(Action.EXTRA_ID, Action.CLICK_ACTION_ID)
                 .putExtra(Options.EXTRA_LAUNCH, options.isLaunchingApp())

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -22,14 +22,15 @@
 package de.appplant.cordova.plugin.notification;
 
 import android.app.PendingIntent;
+import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationCompat.MessagingStyle.Message;
-import android.support.v4.media.app.NotificationCompat.MediaStyle;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationCompat.MessagingStyle.Message;
+import androidx.media.app.NotificationCompat.MediaStyle;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
@@ -374,7 +375,7 @@ public final class Builder {
         int reqCode = random.nextInt();
 
         PendingIntent deleteIntent = PendingIntent.getBroadcast(
-                context, reqCode, intent, FLAG_UPDATE_CURRENT);
+                context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         builder.setDeleteIntent(deleteIntent);
     }
@@ -390,6 +391,13 @@ public final class Builder {
         if (clickActivity == null)
             return;
 
+        Action[] actions = options.getActions();
+        if (actions != null && actions.length > 0 ) {
+          // if actions are defined, the user must click on button actions to launch the app.
+          // Don't make the notification clickable in this case
+          return;
+        }
+
         Intent intent = new Intent(context, clickActivity)
                 .putExtra(Notification.EXTRA_ID, options.getId())
                 .putExtra(Action.EXTRA_ID, Action.CLICK_ACTION_ID)
@@ -402,8 +410,9 @@ public final class Builder {
 
         int reqCode = random.nextInt();
 
-        PendingIntent contentIntent = PendingIntent.getService(
-                context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+        taskStackBuilder.addNextIntentWithParentStack(intent);
+        PendingIntent contentIntent = taskStackBuilder.getPendingIntent(reqCode, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         builder.setContentIntent(contentIntent);
     }
@@ -453,7 +462,7 @@ public final class Builder {
         int reqCode = random.nextInt();
 
         return PendingIntent.getService(
-                context, reqCode, intent, FLAG_UPDATE_CURRENT);
+                context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
     }
 
     /**

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -22,7 +22,6 @@
 package de.appplant.cordova.plugin.notification;
 
 import android.app.PendingIntent;
-import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -408,11 +407,7 @@ public final class Builder {
             intent.putExtras(extras);
         }
 
-        int reqCode = random.nextInt();
-
-        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
-        taskStackBuilder.addNextIntentWithParentStack(intent);
-        PendingIntent contentIntent = taskStackBuilder.getPendingIntent(reqCode, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent contentIntent = PendingIntent.getActivity(context, options.getId(), intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         builder.setContentIntent(contentIntent);
     }
@@ -459,10 +454,8 @@ public final class Builder {
             intent.putExtras(extras);
         }
 
-        int reqCode = random.nextInt();
-
-        return PendingIntent.getService(
-                context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        return PendingIntent.getActivity(
+                context, options.getId(), intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
     }
 
     /**

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -220,7 +220,7 @@ public final class Notification {
                 continue;
 
             PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, FLAG_CANCEL_CURRENT);
+                    context, 0, intent, FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
             try {
                 switch (options.getPrio()) {
@@ -307,7 +307,7 @@ public final class Notification {
             Intent intent = new Intent(action);
 
             PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, 0);
+                    context, 0, intent, PendingIntent.FLAG_IMMUTABLE);
 
             if (pi != null) {
                 getAlarmMgr().cancel(pi);

--- a/src/android/notification/receiver/AbstractClickReceiver.java
+++ b/src/android/notification/receiver/AbstractClickReceiver.java
@@ -21,7 +21,6 @@
 
 package de.appplant.cordova.plugin.notification.receiver;
 
-import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -38,21 +37,22 @@ import static de.appplant.cordova.plugin.notification.action.Action.EXTRA_ID;
  * Abstract content receiver activity for local notifications. Creates the
  * local notification and calls the event functions for further proceeding.
  */
-abstract public class AbstractClickReceiver extends IntentService {
-
-    // Holds a reference to the intent to handle.
-    private Intent intent;
+abstract public class AbstractClickReceiver extends NotificationTrampolineActivity {
 
     public AbstractClickReceiver() {
-        super("LocalNotificationClickReceiver");
+        super();
+    }
+
+    public void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      onHandleIntent(getIntent());
     }
 
     /**
      * Called when local notification was clicked to launch the main intent.
      */
-    @Override
     protected void onHandleIntent(Intent intent) {
-        this.intent        = intent;
+      // Holds a reference to the intent to handle.
 
         if (intent == null)
             return;
@@ -70,7 +70,6 @@ abstract public class AbstractClickReceiver extends IntentService {
             return;
 
         onClick(toast, bundle);
-        this.intent = null;
     }
 
     /**
@@ -86,13 +85,6 @@ abstract public class AbstractClickReceiver extends IntentService {
      */
     protected String getAction() {
         return getIntent().getExtras().getString(EXTRA_ID, CLICK_ACTION_ID);
-    }
-
-    /**
-     * Getter for the received intent.
-     */
-    protected Intent getIntent() {
-        return intent;
     }
 
     /**

--- a/src/android/notification/receiver/NotificationTrampolineActivity.java
+++ b/src/android/notification/receiver/NotificationTrampolineActivity.java
@@ -1,0 +1,43 @@
+package de.appplant.cordova.plugin.notification.receiver;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+
+
+/**
+ * To satitisfy the new android 12 requirement, the broadcast receiver used
+ * to handle click action on a notification, is replaced with a trampoline activity
+ * Note: to handle correctly the case where the application is running in background 
+ * while the action is clicked, set 
+ *  <preference name="AndroidLaunchMode" value="singleInstance"/>
+ *  in the config.xml file.
+ * If you don't add this line, the app is restarted
+ */
+public class NotificationTrampolineActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String packageName = this.getPackageName();
+        Intent launchIntent = this.getPackageManager().getLaunchIntentForPackage(packageName);
+        String mainActivityClassName = launchIntent.getComponent().getClassName();
+        Class mainActivityClass = null;
+        try {
+          mainActivityClass = Class.forName(mainActivityClassName);
+        } catch (ClassNotFoundException e) {
+          e.printStackTrace();
+          return;
+        }
+
+        Intent intent = new Intent(this, mainActivityClass);
+
+        // put activity from stack or instance it it doesn't exist
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(intent);
+    }
+}

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -30,14 +30,8 @@
 #import "FirebasePlugin.h"
 
 #import <objc/runtime.h>
-#if __has_include(<Appboy_iOS_SDK/AppboyKit.h>)
-#import <Appboy_iOS_SDK/AppboyKit.h>
-#elif __has_include(<Appboy-iOS-SDK/Appboy_iOS_SDK.framework/Headers/AppboyKit.h>)
-#import <Appboy-iOS-SDK/Appboy_iOS_SDK.framework/Headers/AppboyKit.h>
-#else
-#import "AppboyKit.h"
-#endif
-#import "AppboyPlugin.h"
+@import BrazeKit;
+#import "BrazePlugin.h"
 
 @interface APPLocalNotification ()
 
@@ -530,7 +524,7 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
                 withCompletionHandler:handler];
     
     if ([mutableUserInfo objectForKey:@"ab"]) {
-        [[Appboy sharedInstance] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:nil];
+        [[Braze sharedInstance] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:nil];
     }
 
     handler();


### PR DESCRIPTION
appboy-cordova-sdk uses [Braze Swift SDK](https://github.com/braze-inc/braze-swift-sdk) since v.2.3.3, replacing the old [Braze iOS SDK](https://github.com/Appboy/appboy-ios-sdk/releases/tag/4.4.2) according to the [migration guide](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/). It still uses some deprecated methods as a result, so this plugin might potentially break again with some other appboy-cordova-sdk update in the future.